### PR TITLE
Create directories recursively

### DIFF
--- a/vsc-base/src/vsc-base-system.ts
+++ b/vsc-base/src/vsc-base-system.ts
@@ -307,7 +307,7 @@ export const isDir = (path: string): boolean => {
  */
 export const makeDir = async (folderPath: string): Promise<void> => {
    try {
-      await fs.mkdir(folderPath)
+      await fs.mkdirs(folderPath)
    } catch (e) {
       throw e
    }


### PR DESCRIPTION
This will cater to the scenario where a template needs to ensure
a directory exists, but not fail if it does.